### PR TITLE
Mention both mainnet and holesky in getting started

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -1,6 +1,6 @@
-# **SSV Holesky**
+# **SSV**
 
-The SSV Network is a decentralized, open-source Ethereum staking network that enhances validator key security and network redundancy using Distributed Validator Technology (DVT). This package allows you to run an SSV Operator Node for the Holesky testnet.
+The SSV Network is a decentralized, open-source Ethereum staking network that enhances validator key security and network redundancy using Distributed Validator Technology (DVT). This package allows you to run an SSV Operator Node on Ethereum mainnet or Holesky testnet.
 
 ## Requirements
 


### PR DESCRIPTION
The generic repo allows the generation of both the `mainnet` SSV packages and the `holesky` one. This PR mentions both variants, following @JHGrove3 advice in https://github.com/dappnode/DAppNodePackage-ssv-generic/pull/4