### PR TITLE
Parse numbers in operator config

### DIFF
--- a/operator/entrypoint.sh
+++ b/operator/entrypoint.sh
@@ -117,6 +117,12 @@ create_operator_config() {
   rm -f "${raw_json_config_file}" "${modified_json_config_file}"
 }
 
+# Parses numbers between quotes into integers
+parse_numbers_in_operator_config() {
+  echo "[INFO] Parsing numbers in the operator config..."
+  sed -i "s/'\([0-9]\+\)'/\1/g" "${NODE_CONFIG_FILE}"
+}
+
 start_operator() {
   echo "[INFO] Starting SSV operator..."
 
@@ -145,6 +151,7 @@ main() {
   handle_private_key
   post_pubkey_to_dappmanager
   create_operator_config
+  parse_numbers_in_operator_config
   start_operator
 }
 


### PR DESCRIPTION
This PR fixes the error:

![Screenshot from 2024-08-23 11-19-14](https://github.com/user-attachments/assets/0597c105-8ee8-4c4a-ab89-307853bc876c)


Which was thrown due to the operator not being able to parse a string into a number