### PR TITLE
use new staker scripts

### DIFF
--- a/operator/entrypoint.sh
+++ b/operator/entrypoint.sh
@@ -13,8 +13,6 @@ export NODE_LOG_FILE=${OPERATOR_LOGS_DIR}/node.log
 DEFAULT_PRIVATE_KEY_FILE=/encrypted_private_key.json
 RAW_NODE_YML_CONFIG_FILE=${NODE_CONFIG_DIR}/raw-node-config.yml
 
-SUPPORTED_NETWORKS="mainnet holesky"
-
 # To use staker scripts
 # shellcheck disable=SC1091
 . /etc/profile
@@ -24,14 +22,13 @@ create_directories() {
 }
 
 assign_execution_endpoint() {
-  # TODO: Set all execution clients WS port to 8546
-  EXECUTION_LAYER_WS=$(get_execution_ws_url_from_global_env "$NETWORK" "$SUPPORTED_NETWORKS")
+  EXECUTION_LAYER_WS=$(get_execution_ws_url_from_global_env "$NETWORK")
 
   export EXECUTION_LAYER_WS
 }
 
 assign_beacon_endpoint() {
-  BEACON_NODE_API=$(get_beacon_api_url_from_global_env "$NETWORK" "$SUPPORTED_NETWORKS")
+  BEACON_NODE_API=$(get_beacon_api_url_from_global_env "$NETWORK")
 
   export BEACON_NODE_API
 }

--- a/package_variants/holesky/dappnode_package.json
+++ b/package_variants/holesky/dappnode_package.json
@@ -7,5 +7,5 @@
       "services": ["operator"]
     }
   ],
-  "shortDescription": "SSV for Holesky"
+  "shortDescription": "SSV for Ethereum Testnet Holesky"
 }

--- a/package_variants/mainnet/dappnode_package.json
+++ b/package_variants/mainnet/dappnode_package.json
@@ -10,5 +10,5 @@
   "optionalDependencies": {
     "nethermind.public.dappnode.eth": ">=1.0.55"
   },
-  "shortDescription": "SSV for Mainnet"
+  "shortDescription": "SSV for Ethereum Mainnet"
 }

--- a/package_variants/mainnet/dappnode_package.json
+++ b/package_variants/mainnet/dappnode_package.json
@@ -7,5 +7,8 @@
       "services": ["operator"]
     }
   ],
+  "optionalDependencies": {
+    "nethermind.public.dappnode.eth": ">=1.0.55"
+  },
   "shortDescription": "SSV for Mainnet"
 }


### PR DESCRIPTION
Should be merged only when https://github.com/dappnode/staker-package-scripts/pull/8 is merged into main & bumped in this repo

This PR:
- adds nethermind generic >= 1.0.55 as optional dependency, since its the nethermind that will support WS in port 8546
- removes unnecesary SUPPORTED_NETWORKS variable not used when https://github.com/dappnode/staker-package-scripts/pull/8 is merged