### PR TITLE
bump ssvlabs/ssv to v2.1.0

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "ssvlabs/ssv",
-      "version": "v2.0.2",
+      "version": "v2.1.0",
       "arg": "OPERATOR_UPSTREAM_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: operator
       args:
-        OPERATOR_UPSTREAM_VERSION: v2.0.2
+        OPERATOR_UPSTREAM_VERSION: v2.1.0
         STAKER_SCRIPTS_VERSION: v0.1.1
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
bump ssvlabs/ssv to v2.1.0,
dappnode/staker-package-scripts remain the same at v0.1.1