### PR TITLE
Bump SSV holesky to `v2.2.2-unstable.0`

### DIFF
--- a/package_variants/holesky/dappnode_package.json
+++ b/package_variants/holesky/dappnode_package.json
@@ -1,6 +1,13 @@
 {
   "name": "ssv-holesky.dnp.dappnode.eth",
   "version": "0.1.9",
+  "upstream": [
+    {
+      "repo": "ssvlabs/ssv",
+      "version": "v2.2.2-unstable.0",
+      "arg": "OPERATOR_UPSTREAM_VERSION"
+    }
+  ],
   "globalEnvs": [
     {
       "envs": ["EXECUTION_CLIENT_HOLESKY", "CONSENSUS_CLIENT_HOLESKY"],

--- a/package_variants/holesky/docker-compose.yml
+++ b/package_variants/holesky/docker-compose.yml
@@ -5,6 +5,7 @@ services:
         NETWORK: holesky
         P2P_TCP_PORT: 12515
         P2P_UDP_PORT: 13515
+        OPERATOR_UPSTREAM_VERSION: v2.2.2-unstable.0
     ports:
       - 12515:12515/tcp
       - 13515:13515/udp


### PR DESCRIPTION
Bumping SSV holesky to `v2.2.2-unstable.0` due Pectra update