### PR TITLE
fix: correct DKG_UPSTREAM_VERSION typo and pin ssv-dkg to v3.0.3

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -7,7 +7,7 @@
     },
     {
       "repo": "ssvlabs/ssv-dkg",
-      "version": "v3.1.0",
+      "version": "v3.0.3",
       "arg": "DKG_UPSTREAM_VERSION"
     },
     {

--- a/dkg/Dockerfile
+++ b/dkg/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage
 FROM alpine:3.21 as build
 
-ARG DGK_UPSTREAM_VERSION
+ARG DKG_UPSTREAM_VERSION
 
 WORKDIR /
 RUN cd /
@@ -11,7 +11,7 @@ RUN apk update
 RUN apk add --no-cache curl zip
 
 # Download given version from Github and unzip
-RUN curl -L -o /ssv-dkg.zip https://github.com/ssvlabs/ssv-dkg/releases/download/${DGK_UPSTREAM_VERSION}/ssvdkg-${DGK_UPSTREAM_VERSION}-linux-$(uname -m | sed -e 's/aarch64/arm64/g' -e 's/x86_64/amd64/g').zip
+RUN curl -L -o /ssv-dkg.zip https://github.com/ssvlabs/ssv-dkg/releases/download/${DKG_UPSTREAM_VERSION}/ssvdkg-${DKG_UPSTREAM_VERSION}-linux-$(uname -m | sed -e 's/aarch64/arm64/g' -e 's/x86_64/amd64/g').zip
 RUN unzip -j /ssv-dkg.zip
 
 # Final stage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     build:
       context: dkg
       args:
-        DGK_UPSTREAM_VERSION: v3.0.3
+        DKG_UPSTREAM_VERSION: v3.0.3
         STAKER_SCRIPTS_VERSION: v0.1.2
     restart: on-failure
     volumes:


### PR DESCRIPTION
## Summary
- Fix `DGK_UPSTREAM_VERSION` -> `DKG_UPSTREAM_VERSION` typo in `dkg/Dockerfile` and `docker-compose.yml`. The `dappnode_package.json` already declared the arg as `DKG_UPSTREAM_VERSION`, so the build was not propagating the version correctly.
- Pin `ssv-dkg` to `v3.0.3` in `dappnode_package.json` to match the build arg in `docker-compose.yml`.

## Changes
- `dappnode_package.json`: `ssvlabs/ssv-dkg` `v3.1.0` -> `v3.0.3`
- `dkg/Dockerfile`: `ARG DGK_UPSTREAM_VERSION` -> `ARG DKG_UPSTREAM_VERSION`
- `docker-compose.yml`: build arg key `DGK_UPSTREAM_VERSION` -> `DKG_UPSTREAM_VERSION` (value unchanged at `v3.0.3`)