### PR TITLE
Use upstream SSV DKG base image

### DIFF
--- a/dkg/Dockerfile
+++ b/dkg/Dockerfile
@@ -1,24 +1,5 @@
-# Build stage
-FROM alpine:3.21 as build
-
 ARG DKG_UPSTREAM_VERSION
-
-WORKDIR /
-RUN cd /
-
-# Install curl and zip
-RUN apk update
-RUN apk add --no-cache curl zip
-
-# Download given version from Github and unzip
-RUN curl -L -o /ssv-dkg.zip https://github.com/ssvlabs/ssv-dkg/releases/download/${DKG_UPSTREAM_VERSION}/ssvdkg-${DKG_UPSTREAM_VERSION}-linux-$(uname -m | sed -e 's/aarch64/arm64/g' -e 's/x86_64/amd64/g').zip
-RUN unzip -j /ssv-dkg.zip
-
-# Final stage
-FROM alpine:3.21
-
-# Copy the built binary from the previous stage/build context
-COPY --from=build /ssv-dkg /bin/ssv-dkg
+FROM ssvlabs/ssv-dkg:${DKG_UPSTREAM_VERSION}
 
 WORKDIR /
 


### PR DESCRIPTION
Summary:
- Use ssvlabs/ssv-dkg as the DKG service base image, pinned by DKG_UPSTREAM_VERSION.
- Remove the Alpine build stage that downloaded and unzipped the DKG binary manually.

Testing:
- docker manifest inspect ssvlabs/ssv-dkg:v3.0.3
- docker build not run locally because the Docker daemon socket is unavailable.